### PR TITLE
Fix hyperlinks

### DIFF
--- a/simple-resume.cls
+++ b/simple-resume.cls
@@ -5,8 +5,6 @@
 \ProcessOptions\relax
 \LoadClass[11pt, letterpaper]{article}
 
-% Required for defining colors
-\RequirePackage{xcolor}
 % Removes paragraph indentations
 \RequirePackage{parskip}
 \RequirePackage{array}
@@ -30,14 +28,8 @@
 % Required for fontawesome icons
 \RequirePackage{fontawesome}
 
-% COLORS
-\definecolor{linkcolor}{HTML}{0000ff}
-
 \hypersetup{
-    ocgcolorlinks,
-    colorlinks,
-    linkcolor=linkcolor,
-    urlcolor=linkcolor
+    hidelinks
 }
 % No header/footers are needed
 \pagestyle{empty}


### PR DESCRIPTION
Closes #2.

Removed the `ocgcolorlinks` option of the `hyperref` package. The hyper links will be by default black.